### PR TITLE
handling situation where user login is undefined

### DIFF
--- a/lib/authors.js
+++ b/lib/authors.js
@@ -78,10 +78,14 @@ function toData(ppl) {
 }
 
 function toMarkdown(p) {
-  var str = '- '
-    + '[' + p.name + ']'
-    + '(https://github.com/' + p.login + ')'
-  if (p.name != p.login) str += ' aka `' + p.login + '`'
+  var str = '- ';
+    if (p.login !== undefined) {
+        str = str + '[' + p.name + ']'
+            + '(https://github.com/' + p.login + ')'
+        if (p.name != p.login) str += ' aka `' + p.login + '`'
+    } else {
+        str = str + p.name;
+    }
   return str
 }
 


### PR DESCRIPTION
If GitHub API search is not able to resolve a committer to a valid GitHub user, the committer name is now listed without a link.

Before this fix, when the user login was resolved to `undefined` entries like this were produced:
- [bkimminich](https://github.com/bkimminich)
- [Horst Schlaemmer](https://github.com/undefined) aka `undefined`

As there actually is a user https://github.com/undefined, he might unduly receive credit for commits he never made...

Example output after fix:
- [bkimminich](https://github.com/bkimminich)
- Horst Schlaemmer

Test case: Running `authors` on https://github.com/bkimminich/AgileSoftwareDevelopmentInPractice
